### PR TITLE
Remove provider definition. (let the caller module specify the provider)

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = var.region
-}


### PR DESCRIPTION
According to a recommended practice, the provider definition was removed to allow the caller module to specify the required provider instance.