### PR TITLE
Add health check support

### DIFF
--- a/datadog_default_task_def.tf
+++ b/datadog_default_task_def.tf
@@ -29,6 +29,11 @@ locals {
           hostPort      = 8126,
           protocol      = "tcp",
           containerPort = 8126
+        },
+        {
+          hostPort      = 5555,
+          protocol      = "tcp",
+          containerPort = 5555
         }
       ],
       secrets = [
@@ -65,6 +70,11 @@ locals {
         {
           name  = "DD_DOGSTATSD_MAPPER_PROFILES",
           value = replace(replace(data.template_file.dd_dogstatsd_mapper_profiles.rendered, "\n", ""), " ", "")
+        },
+        {
+          name  = "DD_HEALTH_PORT",
+          value = "5555"
+
         }
       ],
       mountPoints = [

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,14 @@ resource "aws_security_group" "sg_datadog_internal" {
     cidr_blocks = [local.vpc_cidr_block]
   }
 
+  ingress {
+    description = "Health Check"
+    from_port   = 5555
+    to_port     = 5555
+    protocol    = "tcp"
+    cidr_blocks = [local.vpc_cidr_block]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
This change is about enabling the health check for the Datadog agent container. 